### PR TITLE
Use environment files instead of deprecated commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Export GOPATH
-      run: echo "::set-env name=GOPATH::$(go env GOPATH)"
+      run: echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
     - name: Append GOPATH onto PATH
-      run: echo "::set-env name=PATH::$PATH:$GOPATH/bin"
+      run: echo "$GOPATH/bin" >> $GITHUB_PATH
 
 
     # BUILD


### PR DESCRIPTION
According to [The GitHub Blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), `set-env` and `add-path` are deprecated and no longer available by default. Currently CI can't run successfully because of this.
So I fixed the problem by using environment files instead of using these deprecated commands.

I'm not sure if this will be correct because I'm not so familiar with GitHub Actions.