### PR TITLE
Primitive copy on maps

### DIFF
--- a/main.go
+++ b/main.go
@@ -339,6 +339,10 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 	under := m.Underlying()
 	switch v := under.(type) {
 	case *types.Struct:
+
+		/*fmt.Fprintf(w, `%s = %s
+		`, sink, source)*/
+
 		for i := 0; i < v.NumFields(); i++ {
 			field := v.Field(i)
 			if needExported && !field.Exported() {
@@ -456,6 +460,7 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 			if b.Len() > 0 {
 				ksink = copyKSink
 				fmt.Fprintf(w, "var %s %s\n", ksink, kkind)
+				fmt.Fprintf(w, "%s =  %s\n", ksink, source)
 				b.WriteTo(w)
 			}
 		}
@@ -469,6 +474,7 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 			if b.Len() > 0 {
 				vsink = copyVSink
 				fmt.Fprintf(w, "var %s %s\n", vsink, vkind)
+				fmt.Fprintf(w, "%s =  %s\n", vsink, val)
 				b.WriteTo(w)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -339,10 +339,6 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 	under := m.Underlying()
 	switch v := under.(type) {
 	case *types.Struct:
-
-		/*fmt.Fprintf(w, `%s = %s
-		`, sink, source)*/
-
 		for i := 0; i < v.NumFields(); i++ {
 			field := v.Field(i)
 			if needExported && !field.Exported() {

--- a/main.go
+++ b/main.go
@@ -394,7 +394,10 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 			fmt.Fprintf(w, `    for %s := range %s {
 `, idx, source)
 
-			b.WriteTo(w)
+			_, err := b.WriteTo(w)
+			if err != nil {
+				fmt.Println(err)
+			}
 
 			fmt.Fprintf(w, "}\n")
 		}
@@ -461,7 +464,10 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 				ksink = copyKSink
 				fmt.Fprintf(w, "var %s %s\n", ksink, kkind)
 				fmt.Fprintf(w, "%s =  %s\n", ksink, source)
-				b.WriteTo(w)
+				_, err := b.WriteTo(w)
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 		}
 
@@ -475,7 +481,10 @@ func walkType(source, sink, x string, m types.Type, w io.Writer, imports map[str
 				vsink = copyVSink
 				fmt.Fprintf(w, "var %s %s\n", vsink, vkind)
 				fmt.Fprintf(w, "%s =  %s\n", vsink, val)
-				b.WriteTo(w)
+				_, err := b.WriteTo(w)
+				if err != nil {
+					fmt.Println(err)
+				}
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -70,6 +70,7 @@ func (o Foo) DeepCopy() Foo {
 		cp.Map = make(map[string]*Bar, len(o.Map))
 		for k2, v2 := range o.Map {
 			var cp_Map_v2 *Bar
+			cp_Map_v2 = v2
 			if v2 != nil {
 				cp_Map_v2 = new(Bar)
 				*cp_Map_v2 = *v2
@@ -101,6 +102,7 @@ func (o *Foo) DeepCopy() *Foo {
 		cp.Map = make(map[string]*Bar, len(o.Map))
 		for k2, v2 := range o.Map {
 			var cp_Map_v2 *Bar
+			cp_Map_v2 = v2
 			if v2 != nil {
 				cp_Map_v2 = new(Bar)
 				*cp_Map_v2 = *v2
@@ -132,6 +134,7 @@ func (o *Foo) DeepCopy() *Foo {
 		cp.Map = make(map[string]*Bar, len(o.Map))
 		for k2, v2 := range o.Map {
 			var cp_Map_v2 *Bar
+			cp_Map_v2 = v2
 			if v2 != nil {
 				cp_Map_v2 = new(Bar)
 				*cp_Map_v2 = *v2
@@ -289,10 +292,12 @@ func (o SomeStruct2) DeepCopy() SomeStruct2 {
 		cp.mapStruct = make(map[string]SomeStruct, len(o.mapStruct))
 		for k2, v2 := range o.mapStruct {
 			var cp_mapStruct_v2 SomeStruct
+			cp_mapStruct_v2 = v2
 			if v2.mapSlice != nil {
 				cp_mapStruct_v2.mapSlice = make(map[string][]string, len(v2.mapSlice))
 				for k4, v4 := range v2.mapSlice {
 					var cp_mapStruct_v2_mapSlice_v4 []string
+					cp_mapStruct_v2_mapSlice_v4 = v4
 					if v4 != nil {
 						cp_mapStruct_v2_mapSlice_v4 = make([]string, len(v4))
 						copy(cp_mapStruct_v2_mapSlice_v4, v4)
@@ -317,6 +322,7 @@ func (o SomeStruct) DeepCopy() SomeStruct {
 		cp.mapSlice = make(map[string][]string, len(o.mapSlice))
 		for k2, v2 := range o.mapSlice {
 			var cp_mapSlice_v2 []string
+			cp_mapSlice_v2 = v2
 			if v2 != nil {
 				cp_mapSlice_v2 = make([]string, len(v2))
 				copy(cp_mapSlice_v2, v2)
@@ -334,6 +340,7 @@ func (o SomeStruct2) DeepCopy() SomeStruct2 {
 		cp.mapStruct = make(map[string]SomeStruct, len(o.mapStruct))
 		for k2, v2 := range o.mapStruct {
 			var cp_mapStruct_v2 SomeStruct
+			cp_mapStruct_v2 = v2
 			cp_mapStruct_v2 = v2.DeepCopy()
 			cp.mapStruct[k2] = cp_mapStruct_v2
 		}
@@ -411,6 +418,7 @@ func (o I12StructWithMapOfSlices) DeepCopy() I12StructWithMapOfSlices {
 		cp.Sc1 = make(map[string][]I12StructWithSlices, len(o.Sc1))
 		for k2, v2 := range o.Sc1 {
 			var cp_Sc1_v2 []I12StructWithSlices
+			cp_Sc1_v2 = v2
 			if v2 != nil {
 				cp_Sc1_v2 = make([]I12StructWithSlices, len(v2))
 				copy(cp_Sc1_v2, v2)


### PR DESCRIPTION
Some lint fixes and adding an initial assignment to get primitives copied over.

With code I was working with some values were still empty. Tested on the struct I was having problems with and using a deepequal compare and all seems to be working now.