### PR TITLE
deepcopy.NewGenerator accepts optional functions

### DIFF
--- a/deepcopy/generator.go
+++ b/deepcopy/generator.go
@@ -37,19 +37,55 @@ type Generator struct {
 	fns     [][]byte
 }
 
-func NewGenerator(
-	isPtrRecv bool, methodName string, skipLists SkipLists, maxDepth int, buildTags []string,
-) Generator {
-	return Generator{
-		isPtrRecv:  isPtrRecv,
-		methodName: methodName,
-		maxDepth:   maxDepth,
-		skipLists:  skipLists,
-		buildTags:  buildTags,
+// GeneratorOption is a function to specify option for NewGenerator.
+type GeneratorOption func(*Generator)
 
-		imports: map[string]string{},
-		fns:     [][]byte{},
+// IsPtrRecv is an option to specify isPtrRecv.
+func IsPtrRecv(f bool) GeneratorOption {
+	return func(g *Generator) {
+		g.isPtrRecv = f
 	}
+}
+
+// WithMethodName is an option to specify methodName.
+func WithMethodName(n string) GeneratorOption {
+	return func(g *Generator) {
+		g.methodName = n
+	}
+}
+
+// WithMaxDepth is an option to specify maxDepth.
+func WithMaxDepth(d int) GeneratorOption {
+	return func(g *Generator) {
+		g.maxDepth = d
+	}
+}
+
+// WithSkipLists is an option to specify skipLists
+func WithSkipLists(sl SkipLists) GeneratorOption {
+	return func(g *Generator) {
+		g.skipLists = sl
+	}
+}
+
+// WithBuildTags is an option to specify buildTags
+func WithBuildTags(bts []string) GeneratorOption {
+	return func(g *Generator) {
+		g.buildTags = bts
+	}
+}
+
+// NewGenerator generates a Generator with options.
+func NewGenerator(opts ...GeneratorOption) Generator {
+	g := Generator{
+		methodName: "DeepCopy",
+		imports:    map[string]string{},
+		fns:        [][]byte{},
+	}
+	for _, opt := range opts {
+		opt(&g)
+	}
+	return g
 }
 
 type object interface {

--- a/deepcopy/generator_test.go
+++ b/deepcopy/generator_test.go
@@ -1,0 +1,85 @@
+package deepcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGenerator(t *testing.T) {
+	t.Run("no option", func(t *testing.T) {
+		g := NewGenerator()
+		assert.Equal(t, Generator{
+			methodName: "DeepCopy",
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("isPtrRecv", func(t *testing.T) {
+		g := NewGenerator(IsPtrRecv(true))
+		assert.Equal(t, Generator{
+			methodName: "DeepCopy",
+			isPtrRecv:  true,
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("WithMethodName", func(t *testing.T) {
+		g := NewGenerator(WithMethodName("FuncDeepCopy"))
+		assert.Equal(t, Generator{
+			methodName: "FuncDeepCopy",
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("WithMaxDepth", func(t *testing.T) {
+		g := NewGenerator(WithMaxDepth(15))
+		assert.Equal(t, Generator{
+			methodName: "DeepCopy",
+			maxDepth:   15,
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("WithSkipLists", func(t *testing.T) {
+		sl := SkipLists([]map[string]struct{}{
+			{"foo": struct{}{}},
+			{"bar": struct{}{}},
+		})
+		g := NewGenerator(WithSkipLists(sl))
+		assert.Equal(t, Generator{
+			methodName: "DeepCopy",
+			skipLists:  sl,
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("WithBuildTags", func(t *testing.T) {
+		bts := []string{"foo", "bar"}
+		g := NewGenerator(WithBuildTags(bts))
+		assert.Equal(t, Generator{
+			methodName: "DeepCopy",
+			buildTags:  bts,
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		g := NewGenerator(
+			IsPtrRecv(true),
+			WithMethodName("FuncDeepCopy"),
+		)
+		assert.Equal(t, Generator{
+			isPtrRecv:  true,
+			methodName: "FuncDeepCopy",
+			imports:    map[string]string{},
+			fns:        [][]byte{},
+		}, g)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.13
 
 require (
 	github.com/google/go-cmp v0.5.5
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/tools v0.0.0-20200107050322-53017a39ae36
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -14,3 +26,8 @@ golang.org/x/tools v0.0.0-20200107050322-53017a39ae36/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -137,7 +137,13 @@ func main() {
 	}
 
 	sl := deepcopy.SkipLists(skipsF)
-	generator := deepcopy.NewGenerator(*pointerReceiverF, *methodF, sl, *maxDepthF, buildTagsF)
+	generator := deepcopy.NewGenerator(
+		deepcopy.IsPtrRecv(*pointerReceiverF),
+		deepcopy.WithMethodName(*methodF),
+		deepcopy.WithSkipLists(sl),
+		deepcopy.WithMaxDepth(*maxDepthF),
+		deepcopy.WithBuildTags(buildTagsF),
+	)
 
 	output, err := outputF.Open()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -52,8 +52,13 @@ func Test_run(t *testing.T) {
 			if tt.method != "" {
 				method = tt.method
 			}
-			g := deepcopy.NewGenerator(tt.pointer, method,
-				deepcopy.SkipLists(tt.skips), tt.maxdepth, tt.buildTags)
+			g := deepcopy.NewGenerator(
+				deepcopy.IsPtrRecv(tt.pointer),
+				deepcopy.WithMethodName(method),
+				deepcopy.WithSkipLists(deepcopy.SkipLists(tt.skips)),
+				deepcopy.WithMaxDepth(tt.maxdepth),
+				deepcopy.WithBuildTags(tt.buildTags),
+			)
 			var buf bytes.Buffer
 			err := run(g, &buf, tt.path, tt.types)
 			if err != nil {


### PR DESCRIPTION
issue https://github.com/globusdigital/deep-copy/issues/37

This p-r makes it easy to add options to `deepcopy.NewGenerator()`. It doesn't change any functionality.

